### PR TITLE
Fix header formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,1 @@
 s# github-bot
-comit


### PR DESCRIPTION
sasasas

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the stray "comit" line beneath the README header to fix formatting and keep the title clean. This makes the top of the README show only the project name.

<sup>Written for commit fb3d6cebe3f58c60810bbcc157b48ab6488c4b8f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

